### PR TITLE
Position des Download-Links verbessern (recursive-download-folder_default.html5)

### DIFF
--- a/src/Resources/contao/templates/recursive-download-folder/recursive-download-folder_default.html5
+++ b/src/Resources/contao/templates/recursive-download-folder/recursive-download-folder_default.html5
@@ -5,11 +5,12 @@
   <?php if ($element['is_empty']) : ?>    
     <span title="<?php echo $element['data']['title']; ?>"><?php echo $element['data']['link']; ?></span>
   <?php else : ?>    
-    <a href="<?= $this->generateLink($element) ?>" title="<?php echo $element['data']['title']; ?>"><?php echo $element['data']['link']; ?></a><?php echo $element['elements_rendered']; ?>
+    <a href="<?= $this->generateLink($element) ?>" title="<?php echo $element['data']['title']; ?>"><?php echo $element['data']['link']; ?></a>
+    <?php if ($element['data']['href']): ?>
+      <a href="<?= $element['data']['href'] ?>" class="download-as-zip"><?= $this->trans('MSC.recursiveDownloadFolderDownloadAsZip', [], 'contao_default') ?></a>
+    <?php endif ?>
+    <?php echo $element['elements_rendered']; ?>
   <?php endif; ?>
-  <?php if ($element['data']['href']): ?>
-    <a href="<?= $element['data']['href'] ?>" class="download-as-zip"><?= $this->trans('MSC.recursiveDownloadFolderDownloadAsZip', [], 'contao_default') ?></a>
-  <?php endif ?>
   </li>
   <?php else: ?>
   <li class="download-element <?php echo $element['css_class']; ?>"><a href="<?php echo $element['data']['href']; ?>" title="<?php echo $element['data']['title']; ?>"><?php echo $element['data']['link']; ?> <span class="size">(<?php echo $element['data']['filesize']; ?>)</span></a></li>


### PR DESCRIPTION
Wenn "Ordner herunterladen" aktiviert ist: Bisher rutscht beim Aufklappen eines Ordners der "Ordner-herunterladen"-Link unter den Ordnerinhalt.
Lösung: Verschiebe das "download-as-zip"-Element zwischen Ordnername und Ordnerinhalt.

(mein erster Pull Request nach Vorlage von Contao.random "003" :)